### PR TITLE
EM: Add Android make file for battery host utility

### DIFF
--- a/vm_battery_utility/Android.mk
+++ b/vm_battery_utility/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := batsys
+
+LOCAL_SRC_FILES := battery_sysfsread.c
+
+include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
This patch adds Android make file for battery host utility
so that it can be built as part of target.

Tracked-On: OAM-91272
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>