### PR TITLE
Use clang from prebuilts instead of host gcc

### DIFF
--- a/vm_battery_utility/Makefile
+++ b/vm_battery_utility/Makefile
@@ -1,2 +1,2 @@
 batmake: battery_sysfsread.c
-	gcc -o batsys battery_sysfsread.c -I -Wall -Wpointer-sign -Wmaybe-uninitialized -Wuninitialized -Wunused-parameter
+	clang -o batsys battery_sysfsread.c -I -Wall -Wpointer-sign -Wuninitialized -Wunused-parameter


### PR DESCRIPTION
This is required to enable setup path restrictions
for Android 11

Tracked-On: OAM-95316
Signed-off-by: yaravapa <yasoda.aravapalli@intel.com>